### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         - id: detect-private-key
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.15.6
+      rev: v0.15.11
       hooks:
         - id: ruff-check
           args: ["--fix"]
@@ -34,7 +34,7 @@ repos:
           exclude: CHANGELOG.md
 
     - repo: https://github.com/rhysd/actionlint
-      rev: v1.7.11
+      rev: v1.7.12
       hooks:
         - id: actionlint
 


### PR DESCRIPTION
This PR updates the pre-commit hooks to their latest versions.

Auto-generated by the update-pre-commit workflow.