### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         - id: detect-private-key
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.15.15
+      rev: v0.15.16
       hooks:
         - id: ruff-check
           args: ["--fix"]


### PR DESCRIPTION
This PR updates the pre-commit hooks to their latest versions.

Auto-generated by the update-pre-commit workflow.