### PR TITLE
forward args to subprocess by default, block explicit unsupported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,16 @@ pytest --junitxml=report.xml --durations=10
 
 **Performance**: Subprocess creation adds ~100-500ms per group. Group related tests to minimize overhead. Only mark tests that need isolation.
 
+### CLI Option Compatibility
+
+pytest-isolated uses a forward-by-default (blacklist) model:
+
+- Some options are blocked with a clear `UsageError` when isolation is active.
+- Some options are supported but handled in the parent process (not forwarded).
+- All remaining options (including custom plugin options) are forwarded to children.
+
+See [Incompatible options reference](docs/incompatible-options.md) for the full list and workarounds.
+
 ## Advanced
 
 ### Coverage Integration

--- a/docs/incompatible-options.md
+++ b/docs/incompatible-options.md
@@ -1,0 +1,101 @@
+# Isolation CLI Compatibility
+
+This page separates options into behavior categories so it is clear what is
+blocked, what is parent-handled, and what is forwarded.
+
+Scope: isolation is active when using `@pytest.mark.isolated` or `--isolated`.
+
+Implementation references:
+
+- hard-block validation: `_validate_isolation_compatibility` in `src/pytest_isolated/config.py`
+- block list source: `_INCOMPATIBLE_OPTIONS` in `src/pytest_isolated/config.py`
+- forwarding behavior: `_build_forwarded_args` in `src/pytest_isolated/execution.py`
+
+## Category A: Unsupported with isolation (hard error)
+
+These options are rejected when isolation is active. pytest-isolated raises
+`UsageError`.
+
+### Interactive debugger options
+
+- `--pdb`: requires interactive debugger access
+- `--pdbcls`: requires interactive debugger access
+- `--trace`: requires interactive debugger access
+- `--full-trace`: tied to interactive exception display
+
+### Import and discovery options
+
+- `--confcutdir`: conftest search path differs between parent and child
+- `--noconftest`: parent and child need conftest for consistency
+- `--collect-in-virtualenv`: virtualenv detection may differ per process
+
+### Cache and execution-state options
+
+- `--nf`: file modification times differ between parent and child
+- `--new-first`: file modification times differ between parent and child
+- `--sw`: stepwise state tracking lost across subprocess boundary
+- `--stepwise`: stepwise state tracking lost across subprocess boundary
+- `--sw-skip`: stepwise state tracking lost across subprocess boundary
+- `--sw-reset`: stepwise state tracking lost across subprocess boundary
+- `--cache-show`: shows only parent cache, not subprocess cache
+- `--cache-clear`: clears parent cache only, subprocess cache unaffected
+
+### Configuration selection options
+
+- `-c`: parent and child must use same config file
+- `--config-file`: parent and child must use same config file
+
+### Fixture and execution-control options
+
+- `--setup-only`: setup-only prevents test execution in child
+- `--setup-plan`: setup-plan prevents test execution in child
+
+### Debug and diagnostics options
+
+- `--trace-config`: traces parent conftest, not subprocess conftest
+- `--debug`: subprocess debug output may be lost
+
+### xfail behavior options
+
+- `--runxfail`: xfail handling can be inconsistent between parent and child
+
+## Category B: Supported, parent-handled, not forwarded to child
+
+These options are supported for isolated runs, but are intentionally consumed in
+the parent process and are not forwarded to child subprocesses.
+
+- collection and selection options:
+  `--co`, `--collect-only`, `--pyargs`, `--ignore`, `--ignore-glob`,
+  `--deselect`, `--keep-duplicates`
+- fixture listing options:
+  `--fixtures`, `--funcargs`, `--fixtures-per-test`
+- fixture tracing option:
+  `--setup-show` (capture presentation is handled in parent)
+- `--lf`, `--last-failed`
+- `--ff`, `--failed-first`
+- `-s`, `--capture`, `--capture=...` (capture mode is applied when building
+  the subprocess command)
+- internal plugin flags: `--isolated`, `--isolated-timeout`, `--no-isolation`
+- positional test selectors/paths from CLI (children receive resolved nodeids)
+
+## Category C: Forwarded to child by default
+
+All other options are forwarded, including custom/third-party plugin options.
+
+Examples include plugin loading and plugin-defined options such as `-p`,
+`--disable-plugin-autoload`, and `--continue-on-collection-errors`.
+
+This is the default blacklist model: if an option is not in Category A and not
+explicitly parent-handled in Category B, it is forwarded.
+
+## Bypass Mode
+
+Use `--no-isolation` to run without subprocess isolation. In that mode, Category
+A restrictions do not apply.
+
+## Practical Workarounds
+
+- debugger workflows: use `--no-isolation --pdb`
+- fixture inspection workflows (`--fixtures`, `--setup-show`, etc.): run without isolation
+- stepwise/new-first/cache-debug workflows: run without isolation
+- plugin loading experiments (`-p`, `--disable-plugin-autoload`): run without isolation

--- a/src/pytest_isolated/__init__.py
+++ b/src/pytest_isolated/__init__.py
@@ -1,3 +1,3 @@
 """pytest-isolated: Run pytest tests in isolated subprocesses."""
 
-__version__ = "0.4.4"
+__version__ = "0.5.0"

--- a/src/pytest_isolated/config.py
+++ b/src/pytest_isolated/config.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+import shlex
 from typing import Final
 
 import pytest
@@ -19,33 +22,71 @@ DEFAULT_TIMEOUT: Final = 300
 CONFIG_ATTR_GROUPS: Final = "_subprocess_groups"
 CONFIG_ATTR_GROUP_TIMEOUTS: Final = "_subprocess_group_timeouts"
 
-# Options that should be forwarded to subprocess (flags without values)
-_FORWARD_FLAGS: Final = {
-    "-v",
-    "--verbose",
-    "-q",
-    "--quiet",
-    "-l",
-    "--showlocals",
-    "--strict-markers",
-    "--strict-config",
-    "-x",  # exit on first failure
-    "--exitfirst",
-    # Note: -s is NOT forwarded. Child's capture mode is determined by checking
-    # config.getoption("capture") and explicitly setting -s or --capture=tee-sys.
-    # Note: --pdb is NOT forwarded. Tests run in subprocess cannot use interactive
-    # debugger. When --pdb is detected, isolation is automatically disabled.
+# Incompatible pytest options (cannot be forwarded to subprocess).
+# Forward all other options by default (blacklist approach).
+_INCOMPATIBLE_OPTIONS: Final = {
+    # Interactive/Debugger — require terminal input, unavailable in subprocess
+    "--pdb": "requires interactive debugger access",
+    "--pdbcls": "requires interactive debugger access",
+    "--trace": "requires interactive debugger access",
+    "--full-trace": "tied to interactive exception display",
+    # Import/Discovery — affects module resolution differently in parent vs child
+    "--confcutdir": "conftest search path differs between parent and child",
+    "--noconftest": "parent and child need conftest for consistency",
+    "--collect-in-virtualenv": "virtualenv detection may differ per process",
+    # Caching/State — options that depend on child state remain incompatible
+    "--nf": "file modification times differ between parent and child",
+    "--new-first": "file modification times differ between parent and child",
+    "--sw": "stepwise state tracking lost across subprocess boundary",
+    "--stepwise": "stepwise state tracking lost across subprocess boundary",
+    "--sw-skip": "stepwise state tracking lost across subprocess boundary",
+    "--sw-reset": "stepwise state tracking lost across subprocess boundary",
+    "--cache-show": "shows only parent's cache, not subprocess cache",
+    "--cache-clear": "clears parent cache only, subprocess cache unaffected",
+    # Configuration — config file selection must stay parent/child aligned
+    "-c": "parent and child must use same config file",
+    "--config-file": "parent and child must use same config file",
+    # Fixture/Execution — prevent test execution or affect fixture scope
+    "--setup-only": "setup-only prevents test execution in child",
+    "--setup-plan": "setup-plan prevents test execution in child",
+    # Debug pytest — incomplete debug info from parent only
+    "--trace-config": "traces parent's conftest, not subprocess's",
+    "--debug": "subprocess debug output may be lost",
+    # xfail handling
+    "--runxfail": "xfail handling inconsistent between parent and child",
 }
 
-# Options that should be forwarded to subprocess (options with values)
-_FORWARD_OPTIONS_WITH_VALUE: Final = {
-    "--tb",  # traceback style
-    "-r",  # show extra test summary info
-    "--timeout",  # pytest-timeout plugin timeout value
-    # Note: --capture is NOT forwarded. Child uses tee-sys by default, unless user
-    # specifies -s/--capture=no (which is respected). Parent's --capture controls
-    # what the user sees.
-}
+
+def _validate_isolation_compatibility(config: pytest.Config) -> None:
+    """Check for incompatible options when isolation is requested.
+
+    Raises UsageError if incompatible option is explicitly passed.
+    Also checks PYTEST_ADDOPTS environment variable.
+    """
+    # Get all args passed on CLI
+    cli_args = config.invocation_params.args
+
+    # Collect all args including from PYTEST_ADDOPTS env var
+    all_args = list(cli_args)
+    pytest_addopts = os.environ.get("PYTEST_ADDOPTS", "")
+    if pytest_addopts:
+        # Invalid shell syntax; let pytest handle it
+        with contextlib.suppress(ValueError):
+            all_args.extend(shlex.split(pytest_addopts))
+
+    # Check for incompatible options
+    for arg in all_args:
+        # Handle --option=value format
+        option = arg.split("=")[0] if "=" in arg else arg
+
+        if option in _INCOMPATIBLE_OPTIONS:
+            reason = _INCOMPATIBLE_OPTIONS[option]
+            msg = (
+                f"Option '{option}' is incompatible with @pytest.mark.isolated: "
+                f"{reason}. Use --no-isolation to disable isolation for this run, "
+                f"or remove the option."
+            )
+            raise pytest.UsageError(msg)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/src/pytest_isolated/config.py
+++ b/src/pytest_isolated/config.py
@@ -56,6 +56,61 @@ _INCOMPATIBLE_OPTIONS: Final = {
     "--runxfail": "xfail handling inconsistent between parent and child",
 }
 
+# Subset of _INCOMPATIBLE_OPTIONS that consume a following value token.
+_INCOMPATIBLE_OPTIONS_WITH_VALUE: Final = {
+    "--pdbcls",
+    "--confcutdir",
+    "-c",
+    "--config-file",
+    "--debug",
+}
+
+# Parent-handled flags (no value) — resolved before subprocess split, not forwarded.
+_PARENT_HANDLED_FLAGS: Final = {
+    "--co",
+    "--collect-only",
+    "--pyargs",
+    "--keep-duplicates",
+    "--fixtures",
+    "--funcargs",
+    "--fixtures-per-test",
+    "--lf",
+    "--last-failed",
+    "--ff",
+    "--failed-first",
+    "-s",
+    "--isolated",
+    "--no-isolation",
+}
+
+# Parent-handled options that consume a following value token.
+_PARENT_HANDLED_WITH_VALUE: Final = {
+    "--ignore",
+    "--ignore-glob",
+    "--deselect",
+    "--capture",
+    "--isolated-timeout",
+}
+
+# Forwarded options that consume a following value token (separate form: --opt value).
+_FORWARDED_OPTIONS_WITH_VALUE: Final = {
+    "-o",
+    "--override-ini",
+    "-p",
+    "--tb",
+    "-r",
+    "--maxfail",
+    "-k",
+    "-m",
+    "--import-mode",
+    "--rootdir",
+    "--basetemp",
+    "--durations",
+    "--durations-min",
+    "--junitxml",
+    "--timeout",
+}
+
 
 def _validate_isolation_compatibility(config: pytest.Config) -> None:
     """Check for incompatible options when isolation is requested.

--- a/src/pytest_isolated/execution.py
+++ b/src/pytest_isolated/execution.py
@@ -16,8 +16,6 @@ from typing import Literal, NamedTuple, TypeAlias, cast
 import pytest
 
 from .config import (
-    _FORWARD_FLAGS,
-    _FORWARD_OPTIONS_WITH_VALUE,
     CONFIG_ATTR_GROUP_TIMEOUTS,
     CONFIG_ATTR_GROUPS,
     DEFAULT_TIMEOUT,
@@ -53,32 +51,118 @@ class ExecutionContext(NamedTuple):
 
 
 def _build_forwarded_args(config: pytest.Config) -> list[str]:
-    """Build list of pytest arguments to forward to subprocess."""
+    """Forward all args except those explicitly unsupported or parent-resolved."""
+
+    # Options that should NOT be forwarded (parent-handled + incompatible)
+    skip_options = {
+        "--co",
+        "--collect-only",
+        "--pyargs",
+        "--ignore",
+        "--ignore-glob",
+        "--deselect",
+        "--keep-duplicates",
+        "--fixtures",
+        "--funcargs",
+        "--fixtures-per-test",
+        "--lf",
+        "--last-failed",
+        "--ff",
+        "--failed-first",
+        "-s",
+        "--capture",
+        "--isolated",
+        "--isolated-timeout",
+        "--no-isolation",
+        "--pdb",
+        "--pdbcls",
+        "--trace",
+        "--full-trace",
+        "--confcutdir",
+        "--noconftest",
+        "--nf",
+        "--new-first",
+        "--sw",
+        "--stepwise",
+        "--sw-skip",
+        "--sw-reset",
+        "--cache-show",
+        "--cache-clear",
+        "-c",
+        "--config-file",
+        "--setup-only",
+        "--setup-plan",
+        "--trace-config",
+        "--debug",
+        "--runxfail",
+        "--collect-in-virtualenv",
+    }
+
+    # Options that consume a following value token
+    options_with_value = {
+        "-o",
+        "--override-ini",
+        "-p",
+        "--tb",
+        "-r",
+        "--maxfail",
+        "-k",
+        "-m",
+        "--import-mode",
+        "--rootdir",
+        "--basetemp",
+        "--durations",
+        "--durations-min",
+        "--junitxml",
+        "--timeout",
+    }
+
     forwarded_args: list[str] = []
     i = 0
     args = config.invocation_params.args
+
     while i < len(args):
         arg = args[i]
 
-        # Forward only explicitly allowed options
-        if arg in _FORWARD_FLAGS:
-            forwarded_args.append(arg)
+        # Skip positional selectors
+        if not arg.startswith("-"):
             i += 1
-        elif arg in _FORWARD_OPTIONS_WITH_VALUE:
-            forwarded_args.append(arg)
-            # Next arg is the value - forward it too
-            if i + 1 < len(args):
-                forwarded_args.append(args[i + 1])
-                i += 2
+            continue
+
+        # Handle --opt=value form
+        if "=" in arg:
+            option = arg.split("=")[0]
+            if option not in skip_options:
+                forwarded_args.append(arg)
+            i += 1
+            continue
+
+        # Skip blacklisted options
+        if arg in skip_options:
+            if (
+                arg in options_with_value
+                and i + 1 < len(args)
+                and not args[i + 1].startswith("-")
+            ):
+                i += 2  # Skip option and its value
             else:
                 i += 1
-        elif arg.startswith(tuple(f"{opt}=" for opt in _FORWARD_OPTIONS_WITH_VALUE)):
-            forwarded_args.append(arg)
-            i += 1
+            continue
+
+        # Forward all other options
+        forwarded_args.append(arg)
+
+        # If it takes a value, forward that too
+        if (
+            arg in options_with_value
+            and i + 1 < len(args)
+            and not args[i + 1].startswith("-")
+        ):
+            forwarded_args.append(args[i + 1])
+            i += 2
         else:
-            # Skip everything else (positional args, test paths,
-            # unknown options)
             i += 1
+
     return forwarded_args
 
 
@@ -491,6 +575,18 @@ def pytest_runtestloop(session: pytest.Session) -> int | None:
         start_time = time.time()
         result = _run_subprocess(cmd, env, group_timeout, subprocess_cwd)
         execution_time = time.time() - start_time
+
+        # --setup-show prints fixture lifecycle to terminal output in child.
+        # Re-emit those lines so users can see setup/teardown info for isolated tests.
+        if config.getoption("setupshow", False) and result.stdout:
+            stdout_text = result.stdout.decode("utf-8", errors="replace")
+            setup_lines = [
+                line
+                for line in stdout_text.splitlines()
+                if "SETUP" in line or "TEARDOWN" in line
+            ]
+            if setup_lines:
+                sys.stdout.write("\n".join(setup_lines) + "\n")
 
         # Parse results
         results = _parse_results(report_path)

--- a/src/pytest_isolated/execution.py
+++ b/src/pytest_isolated/execution.py
@@ -55,22 +55,19 @@ class ExecutionContext(NamedTuple):
     session: pytest.Session
 
 
-# Derived from config.py constants — single source of truth for option classification.
-_SKIP_OPTIONS: Final = (
-    set(_INCOMPATIBLE_OPTIONS) | _PARENT_HANDLED_FLAGS | _PARENT_HANDLED_WITH_VALUE
-)
-_OPTIONS_WITH_VALUE: Final = (
-    _INCOMPATIBLE_OPTIONS_WITH_VALUE
-    | _PARENT_HANDLED_WITH_VALUE
-    | _FORWARDED_OPTIONS_WITH_VALUE
-)
-
-
 def _build_forwarded_args(config: pytest.Config) -> list[str]:
     """Forward all args except those explicitly unsupported or parent-resolved."""
 
-    skip_options = _SKIP_OPTIONS
-    options_with_value = _OPTIONS_WITH_VALUE
+    # Not forwarded
+    skip_options: Final = (
+        set(_INCOMPATIBLE_OPTIONS) | _PARENT_HANDLED_FLAGS | _PARENT_HANDLED_WITH_VALUE
+    )
+    # Key value options: here we expect a value
+    options_with_value: Final = (
+        _INCOMPATIBLE_OPTIONS_WITH_VALUE
+        | _PARENT_HANDLED_WITH_VALUE
+        | _FORWARDED_OPTIONS_WITH_VALUE
+    )
 
     forwarded_args: list[str] = []
     i = 0

--- a/src/pytest_isolated/execution.py
+++ b/src/pytest_isolated/execution.py
@@ -11,11 +11,16 @@ import tempfile
 import time
 from collections import OrderedDict
 from pathlib import Path
-from typing import Literal, NamedTuple, TypeAlias, cast
+from typing import Final, Literal, NamedTuple, TypeAlias, cast
 
 import pytest
 
 from .config import (
+    _FORWARDED_OPTIONS_WITH_VALUE,
+    _INCOMPATIBLE_OPTIONS,
+    _INCOMPATIBLE_OPTIONS_WITH_VALUE,
+    _PARENT_HANDLED_FLAGS,
+    _PARENT_HANDLED_WITH_VALUE,
     CONFIG_ATTR_GROUP_TIMEOUTS,
     CONFIG_ATTR_GROUPS,
     DEFAULT_TIMEOUT,
@@ -50,72 +55,22 @@ class ExecutionContext(NamedTuple):
     session: pytest.Session
 
 
+# Derived from config.py constants — single source of truth for option classification.
+_SKIP_OPTIONS: Final = (
+    set(_INCOMPATIBLE_OPTIONS) | _PARENT_HANDLED_FLAGS | _PARENT_HANDLED_WITH_VALUE
+)
+_OPTIONS_WITH_VALUE: Final = (
+    _INCOMPATIBLE_OPTIONS_WITH_VALUE
+    | _PARENT_HANDLED_WITH_VALUE
+    | _FORWARDED_OPTIONS_WITH_VALUE
+)
+
+
 def _build_forwarded_args(config: pytest.Config) -> list[str]:
     """Forward all args except those explicitly unsupported or parent-resolved."""
 
-    # Options that should NOT be forwarded (parent-handled + incompatible)
-    skip_options = {
-        "--co",
-        "--collect-only",
-        "--pyargs",
-        "--ignore",
-        "--ignore-glob",
-        "--deselect",
-        "--keep-duplicates",
-        "--fixtures",
-        "--funcargs",
-        "--fixtures-per-test",
-        "--lf",
-        "--last-failed",
-        "--ff",
-        "--failed-first",
-        "-s",
-        "--capture",
-        "--isolated",
-        "--isolated-timeout",
-        "--no-isolation",
-        "--pdb",
-        "--pdbcls",
-        "--trace",
-        "--full-trace",
-        "--confcutdir",
-        "--noconftest",
-        "--nf",
-        "--new-first",
-        "--sw",
-        "--stepwise",
-        "--sw-skip",
-        "--sw-reset",
-        "--cache-show",
-        "--cache-clear",
-        "-c",
-        "--config-file",
-        "--setup-only",
-        "--setup-plan",
-        "--trace-config",
-        "--debug",
-        "--runxfail",
-        "--collect-in-virtualenv",
-    }
-
-    # Options that consume a following value token
-    options_with_value = {
-        "-o",
-        "--override-ini",
-        "-p",
-        "--tb",
-        "-r",
-        "--maxfail",
-        "-k",
-        "-m",
-        "--import-mode",
-        "--rootdir",
-        "--basetemp",
-        "--durations",
-        "--durations-min",
-        "--junitxml",
-        "--timeout",
-    }
+    skip_options = _SKIP_OPTIONS
+    options_with_value = _OPTIONS_WITH_VALUE
 
     forwarded_args: list[str] = []
     i = 0

--- a/src/pytest_isolated/grouping.py
+++ b/src/pytest_isolated/grouping.py
@@ -40,7 +40,12 @@ from typing import Any
 
 import pytest
 
-from .config import CONFIG_ATTR_GROUP_TIMEOUTS, CONFIG_ATTR_GROUPS, SUBPROC_ENV
+from .config import (
+    CONFIG_ATTR_GROUP_TIMEOUTS,
+    CONFIG_ATTR_GROUPS,
+    SUBPROC_ENV,
+    _validate_isolation_compatibility,
+)
 
 
 def _has_isolated_marker(obj: Any) -> bool:
@@ -85,6 +90,15 @@ def pytest_collection_modifyitems(
 
     # If --isolated is set, run all tests in isolation
     run_all_isolated = config.getoption("isolated", False)
+
+    # Check if there are any @pytest.mark.isolated tests
+    has_isolated_tests = run_all_isolated or any(
+        item.get_closest_marker("isolated") for item in items
+    )
+
+    # Validate incompatible options early if isolation will be used
+    if has_isolated_tests:
+        _validate_isolation_compatibility(config)
 
     groups: OrderedDict[str, list[pytest.Item]] = OrderedDict()
     group_timeouts: dict[str, int | None] = {}  # Track timeout per group

--- a/tests/test_execution_units.py
+++ b/tests/test_execution_units.py
@@ -94,7 +94,7 @@ class TestBuildForwardedArgs:
         assert "tests/test_bar.py::test_baz" not in result
 
     def test_excludes_unknown_options(self) -> None:
-        """Test that unknown options are not forwarded."""
+        """Test that unknown options are forwarded by default."""
         config = Mock()
         config.invocation_params.args = [
             "-v",
@@ -106,8 +106,31 @@ class TestBuildForwardedArgs:
         result = _build_forwarded_args(config)
 
         assert "-v" in result
-        assert "--unknown-option" not in result
+        assert "--unknown-option" in result
         assert "--isolated" not in result
+
+    def test_parent_handled_equals_form_not_forwarded(self) -> None:
+        """Test that parent-handled --opt=value options are not forwarded."""
+        config = Mock()
+        config.invocation_params.args = ["--ignore=tests/legacy", "-v"]
+        config._parser = None
+
+        result = _build_forwarded_args(config)
+
+        assert "--ignore=tests/legacy" not in result
+        assert "-v" in result
+
+    def test_unknown_flag_does_not_consume_positional_selector(self) -> None:
+        """Test unknown flags don't swallow positional test selectors as values."""
+        config = Mock()
+        config.invocation_params.args = ["--custom-flag", "tests/test_x.py", "-v"]
+        config._parser = None
+
+        result = _build_forwarded_args(config)
+
+        assert "--custom-flag" in result
+        assert "tests/test_x.py" not in result
+        assert "-v" in result
 
     def test_handles_empty_args(self) -> None:
         """Test handling of empty args list."""

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3,6 +3,9 @@
 Tests command-line options and plugin configuration.
 """
 
+import contextlib
+import os
+import sys
 import textwrap
 
 from pytest import Pytester
@@ -222,3 +225,281 @@ def test_failed_first_with_isolated_tests(pytester: Pytester):
     assert output.index("test_fail FAILED") < output.index("test_good1 PASSED"), (
         "test_fail should run before test_good1 with --ff"
     )
+
+
+# Phase 1.5: Tests for PYTEST_ADDOPTS support and incompatible options
+
+
+def test_custom_option_forwarded_to_subprocess(pytester: Pytester):
+    """Test that custom pytest plugin options are forwarded to subprocess (issue #48).
+
+    This tests the new blacklist-based forwarding approach: custom options should
+    be forwarded by default unless explicitly blacklisted.
+    """
+    # Add a custom option via conftest
+    conftest_code = textwrap.dedent(
+        """
+        import pytest
+
+        def pytest_addoption(parser):
+            parser.addoption(
+                "--eval-solution-path",
+                action="store",
+                default=None,
+                help="Path to evaluation solution",
+            )
+
+        @pytest.fixture
+        def eval_path(request):
+            return request.config.getoption("--eval-solution-path")
+        """
+    )
+    pytester.makeconftest(conftest_code)
+
+    pytester.makepyfile(
+        """
+        import pytest
+
+        def test_non_isolated_with_option(eval_path):
+            assert eval_path == "/path/to/solution", (
+                f"Expected /path/to/solution, got {eval_path}"
+            )
+
+        @pytest.mark.isolated
+        def test_isolated_with_option(eval_path):
+            assert eval_path == "/path/to/solution", (
+                f"Expected /path/to/solution, got {eval_path}"
+            )
+        """
+    )
+
+    # Run with the custom option
+    result = pytester.runpytest("-v", "--eval-solution-path=/path/to/solution")
+    result.assert_outcomes(passed=2)
+
+
+def test_pytest_addopts_env_var_forwarded(pytester: Pytester):
+    """Test that PYTEST_ADDOPTS environment variable is inherited in subprocess.
+
+    PYTEST_ADDOPTS is a standard pytest feature for passing default options.
+    The subprocess should inherit it from the parent's environment.
+    """
+    pytester.makeconftest(
+        textwrap.dedent(
+            """
+            import pytest
+
+            def pytest_addoption(parser):
+                parser.addoption(
+                    "--custom-flag",
+                    action="store_true",
+                    default=False,
+                )
+
+            @pytest.fixture
+            def custom_enabled(request):
+                return request.config.getoption("--custom-flag")
+            """
+        )
+    )
+
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.isolated
+        def test_with_env_option(custom_enabled):
+            assert custom_enabled is True
+        """
+    )
+
+    # Use monkeypatch to set PYTEST_ADDOPTS in the environment
+    original_addopts = os.environ.get("PYTEST_ADDOPTS")
+    try:
+        os.environ["PYTEST_ADDOPTS"] = "--custom-flag"
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=1)
+    finally:
+        if original_addopts is None:
+            os.environ.pop("PYTEST_ADDOPTS", None)
+        else:
+            os.environ["PYTEST_ADDOPTS"] = original_addopts
+
+
+def test_incompatible_option_collect_only_error(pytester: Pytester):
+    """Test that --collect-only is supported with isolated tests."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.isolated
+        def test_example():
+            assert True
+        """
+    )
+
+    # Run with --collect-only - should succeed (parent-handled, no forwarding)
+    result = pytester.runpytest("-v", "--collect-only")
+    assert result.ret == 0
+    output = result.stdout.str()
+    assert "collected" in output
+
+
+def test_incompatible_option_lf_error(pytester: Pytester):
+    """Test that --lf (last-failed) is supported with isolated tests."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.isolated
+        def test_example():
+            assert True
+        """
+    )
+
+    # Run with --lf - should succeed (handled by parent process)
+    result = pytester.runpytest("-v", "--lf")
+    assert result.ret == 0
+
+
+def test_incompatible_option_with_no_isolation_allowed(pytester: Pytester):
+    """Test that incompatible options are allowed when --no-isolation is used.
+
+    When users opt out of isolation, they should be able to use any option,
+    including those that are incompatible with isolation.
+    """
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.isolated
+        def test_example():
+            assert True
+        """
+    )
+
+    # Run with --no-isolation --pdb - should NOT error
+    # (--pdb is normally incompatible, but allowed with --no-isolation)
+    result = pytester.runpytest("-v", "--no-isolation", "--pdb")
+    # With --no-isolation, we skip tests that require interaction
+    # So exit code 0 is expected (no tests actually run with pdb without input)
+    assert result.ret == 0
+
+
+def test_setup_show_with_isolated_tests(pytester: Pytester):
+    """Test that --setup-show displays fixture setup for isolated tests (#47)."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def some_fixture():
+            return "value"
+
+        @pytest.mark.isolated
+        def test_isolated_with_fixture(some_fixture):
+            assert some_fixture == "value"
+        """
+    )
+
+    result = pytester.runpytest("-v", "--setup-show")
+    result.assert_outcomes(passed=1)
+    output = result.stdout.str()
+    assert "SETUP" in output
+    assert "some_fixture" in output
+
+
+def test_p_option_plugin_loaded_in_isolated_subprocess(pytester: Pytester):
+    """Test that -p loaded plugins are available in isolated subprocesses."""
+
+    pytester.path.joinpath("myplugin.py").write_text(
+        textwrap.dedent(
+            """
+            import pytest
+
+            @pytest.fixture
+            def plugin_fixture():
+                return "from-plugin"
+            """
+        )
+    )
+    pytester.makepyfile(
+        test_sample="""
+        import pytest
+
+        @pytest.mark.isolated
+        def test_uses_plugin_fixture(plugin_fixture):
+            assert plugin_fixture == "from-plugin"
+        """,
+    )
+
+    original_pythonpath = os.environ.get("PYTHONPATH")
+    inserted_path = str(pytester.path)
+    os.environ["PYTHONPATH"] = (
+        inserted_path
+        if not original_pythonpath
+        else f"{inserted_path}{os.pathsep}{original_pythonpath}"
+    )
+    sys.path.insert(0, inserted_path)
+    try:
+        result = pytester.runpytest("-v", "-p", "myplugin")
+        result.assert_outcomes(passed=1)
+    finally:
+        if original_pythonpath is None:
+            os.environ.pop("PYTHONPATH", None)
+        else:
+            os.environ["PYTHONPATH"] = original_pythonpath
+        with contextlib.suppress(ValueError):
+            sys.path.remove(inserted_path)
+
+
+def test_continue_on_collection_errors_with_isolated_tests(pytester: Pytester):
+    """Test that parent collection can continue and still run isolated tests."""
+    pytester.makepyfile(
+        test_broken="""
+        raise RuntimeError("collection boom")
+        """,
+        test_isolated_ok="""
+        import pytest
+
+        @pytest.mark.isolated
+        def test_ok():
+            assert True
+        """,
+    )
+
+    result = pytester.runpytest("-v", "--continue-on-collection-errors")
+    output = result.stdout.str() + result.stderr.str()
+    assert "test_ok PASSED" in output
+    assert "collection boom" in output
+
+
+def test_import_mode_forwarded_to_isolated_subprocess(pytester: Pytester):
+    """Test that --import-mode is forwarded to isolated subprocesses."""
+    pkg = pytester.mkdir("pkg")
+    (pkg / "__init__.py").write_text("")
+    (pkg / "helpers.py").write_text(
+        textwrap.dedent(
+            """
+            def helper_value():
+                return "ok"
+            """
+        )
+    )
+    (pkg / "test_import_mode.py").write_text(
+        textwrap.dedent(
+            """
+            import pytest
+            from .helpers import helper_value
+
+            @pytest.mark.isolated
+            def test_uses_relative_import():
+                assert helper_value() == "ok"
+            """
+        )
+    )
+
+    result = pytester.runpytest(
+        "-v", "--import-mode=importlib", "pkg/test_import_mode.py"
+    )
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
**MR Summary**

Switched pytest-isolated to a blacklist model for CLI forwarding: options are now forwarded to child subprocesses by default, and only a small explicit set of truly incompatible options is blocked. This improves plugin and custom-option compatibility.

**What changed**
- Updated forwarding behavior to “allow by default” with explicit blocklist validation in config.py and orchestration adjustments in execution.py.
- Kept parent-only handling where appropriate (for options resolved before child execution), with compatibility checks integrated via grouping.py.
- Added/expanded regression coverage for custom options and key compatibility scenarios in test_options.py and test_execution_units.py.
- Documented the new compatibility taxonomy:
  - unsupported options
  - supported but parent-handled options
  - forwarded-by-default options  
  in incompatible-options.md, plus a high-level note in README.md.


## Related

- closes https://github.com/dyollb/pytest-isolated/issues/47
- closes https://github.com/dyollb/pytest-isolated/issues/48
